### PR TITLE
PS-6919 Patch for named_scope

### DIFF
--- a/activerecord/lib/active_record/named_scope.rb
+++ b/activerecord/lib/active_record/named_scope.rb
@@ -102,6 +102,10 @@ module ActiveRecord
         singleton_class.send :define_method, name do |*args|
           scopes[name].call(self, *args)
         end
+        
+        subclasses.each do |s|
+          s.scopes[name] = scopes[name]
+        end
       end
     end
 

--- a/activerecord/test/cases/named_scope_test.rb
+++ b/activerecord/test/cases/named_scope_test.rb
@@ -349,6 +349,11 @@ class NamedScopeTest < ActiveRecord::TestCase
       Comment.for_first_post.for_first_author.all
     end
   end
+  
+  def test_dynamically_added_scopes_are_inherited
+    Comment.named_scope :thoughtful, :conditions => "body LIKE '%think%'"
+    assert_equal SpecialComment.thoughtful.find(3), SpecialComment.find(3)
+  end
 end
 
 class DynamicScopeMatchTest < ActiveRecord::TestCase  


### PR DESCRIPTION
Patch for named_scope to be correctly populated from parent to children.

[PS-6919 Undefined method `call` errors](https://blurb-books.atlassian.net/browse/PS-6919)